### PR TITLE
Initialize encoding/decoding buffers with null pointers closes #1

### DIFF
--- a/src/slipstream_client.c
+++ b/src/slipstream_client.c
@@ -91,6 +91,8 @@ ssize_t client_encode_segment(dns_packet_t* packet, size_t* packet_len, const un
 }
 
 ssize_t client_encode(void* slot_p, void* callback_ctx, unsigned char** dest_buf, const unsigned char* src_buf, size_t src_buf_len, size_t* segment_len, struct sockaddr_storage* peer_addr, struct sockaddr_storage* local_addr) {
+    *dest_buf = NULL;
+
     // optimize path for single segment
     if (src_buf_len <= *segment_len) {
 #ifdef NOENCODE

--- a/src/slipstream_server.c
+++ b/src/slipstream_server.c
@@ -31,6 +31,8 @@ char* server_domain_name = NULL;
 size_t server_domain_name_len = 0;
 
 ssize_t server_encode(void* slot_p, void* callback_ctx, unsigned char** dest_buf, const unsigned char* src_buf, size_t src_buf_len, size_t* segment_len, struct sockaddr_storage* peer_addr, struct sockaddr_storage* local_addr) {
+    *dest_buf = NULL;
+
     // we don't support segmentation in the server
     assert(segment_len == NULL || *segment_len == 0 || *segment_len == src_buf_len);
 

--- a/src/slipstream_sockloop.c
+++ b/src/slipstream_sockloop.c
@@ -126,7 +126,7 @@ int slipstream_packet_loop_(picoquic_network_thread_ctx_t* thread_ctx, picoquic_
             slot->path_id = -1;
             nb_slots_written++;
 
-            unsigned char* decoded;
+            unsigned char* decoded = NULL;
             bytes_recv = param->decode(slot, thread_ctx->loop_callback_ctx, &decoded,
                 (const unsigned char*)buffer, bytes_recv, &peer_addr, &local_addr);
             if (bytes_recv < 0) {
@@ -208,7 +208,7 @@ int slipstream_packet_loop_(picoquic_network_thread_ctx_t* thread_ctx, picoquic_
 
             int sock_err = 0;
             int bytes_sent;
-            unsigned char* encoded;
+            unsigned char* encoded = NULL;
             size_t segment_len = send_msg_size == 0 ? send_length : send_msg_size;
             ssize_t encoded_len = param->encode(slot, loop_callback_ctx, &encoded,
                 (const unsigned char*)send_buffer, send_length, &segment_len, &peer_addr, &local_addr);
@@ -279,7 +279,7 @@ int slipstream_packet_loop_(picoquic_network_thread_ctx_t* thread_ctx, picoquic_
 
             int sock_err = 0;
             int bytes_sent;
-            unsigned char* encoded;
+            unsigned char* encoded = NULL;
             size_t segment_len = send_msg_size == 0 ? send_length : send_msg_size;
             ssize_t encoded_len = param->encode(slot, loop_callback_ctx, &encoded,
                 (const unsigned char*)send_buffer, send_length, &segment_len, &peer_addr, &local_addr);


### PR DESCRIPTION
> the caller has no way to know if they need to free it or not

while this is not necessarily true--the buffer is only allocated on succesful return codes--it is indeed better practice to ensure the pointers are nullified. This prevents future accidental mal-use leading to corruption when freeing an uninitialized pointer.