### PR TITLE
meson: fix BUILD_LOGLIB not reaching slipstream sources

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,7 @@ if loglib_enabled
   picoquic_opts.add_cmake_defines(
     {'BUILD_LOGREADER': 'ON'},
   )
+  add_project_arguments('-DBUILD_LOGLIB', language: ['c', 'cpp'])
 else
   picoquic_opts.add_cmake_defines(
     {'BUILD_LOGREADER': 'OFF'},


### PR DESCRIPTION
Meson's `build_loglib` option was only applied to `picoquic`'s CMake configuration, but not exposed as a macro define to slipstream sources.

This caused `BUILD_LOGLIB`-guarded code to be excluded at compile time and `qlog` output not to be written to `./qlog/`, even when `picoquic-loglib` was built and linked.