### PR TITLE
docker: add libgcc runtime dependency to prevent pthread_exit abort

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ FROM gcr.io/distroless/base-debian12 AS runtime
 
 WORKDIR /usr/src/app
 
+COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+
 COPY ./certs/ ./certs/
 
 ENV PATH=/usr/src/app/:$PATH


### PR DESCRIPTION
Fixes #23

When connecting via SSH (e.g. for tunneling), the container could crash with:
"libgcc_s.so.1 must be installed for pthread_exit to work"

Root cause: the final runtime image was missing libgcc_s.so.1.

Change:
- Copy libgcc_s.so.1 from the builder stage into the runtime stage:
  COPY --from=builder /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/

Tested:
- Built the Docker image locally and verified SSH connect/disconnect no longer terminates the container.