### PR TITLE
fix(build): add missing picotls dependencies for static linking

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -100,6 +100,10 @@ picoquic_proj = cmake.subproject(
 slipstream_cli_deps = [
   dependency('threads'), # for picoquic
   picoquic_proj.dependency('picoquic-core'),
+  picoquic_proj.dependency('picotls-core'),
+  picoquic_proj.dependency('picotls-minicrypto'),
+  picoquic_proj.dependency('picotls-openssl'),
+  picoquic_proj.dependency('picotls-fusion'),
 ]
 # Link optional picoquic logging
 if loglib_enabled


### PR DESCRIPTION
When building with -Ddefault_library=static, the linker fails with undefined references to ptls_* symbols (e.g., ptls_free, ptls_aead_new).

It seems that Meson's CMake integration does not propagate transitive dependencies, so we seem to have to make it explicit.